### PR TITLE
expect __docgenInfo to be before the HoC call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.log
 lib
 *.DS_Store
+.vscode

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,14 @@ function injectReactDocgenInfo(path, state, code, t) {
         t.memberExpression(t.identifier(exportName), t.identifier('__docgenInfo')),
         docNode
       ));
-    program.pushContainer('body', docgenInfo);
+
+    const defaultExportDeclaration = program.get('body').find(t.isExportDefaultDeclaration);
+
+    if (defaultExportDeclaration) {
+      defaultExportDeclaration.insertBefore(docgenInfo);
+    } else {
+      program.pushContainer('body', docgenInfo);
+    }
 
     injectDocgenGlobal(exportName, path, state, t);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,13 @@ function injectReactDocgenInfo(path, state, code, t) {
         docNode
       ));
 
-    const defaultExportDeclaration = program.get('body').find(t.isExportDefaultDeclaration);
+    const defaultExportDeclaration = program.get('body').find((node) => {
+      const isHoC = t.isCallExpression(node.get('declaration').node)
+      return (
+        t.isExportDefaultDeclaration(node) &&
+        (node.get('declaration').node.name === exportName || isHoC)
+      );
+    });
 
     if (defaultExportDeclaration) {
       defaultExportDeclaration.insertBefore(docgenInfo);

--- a/test/fixtures/case2/expected.js
+++ b/test/fixtures/case2/expected.js
@@ -56,8 +56,6 @@ function (_React$Component) {
 ErrorBox.propTypes = {
   children: _react["default"].PropTypes.node.isRequired
 };
-var _default = ErrorBox;
-exports["default"] = _default;
 ErrorBox.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -72,6 +70,8 @@ ErrorBox.__docgenInfo = {
     }
   }
 };
+var _default = ErrorBox;
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/case2/actual.js"] = {

--- a/test/fixtures/case3/expected.js
+++ b/test/fixtures/case3/expected.js
@@ -25,17 +25,6 @@ Button.propTypes = {
   onClick: _react["default"].PropTypes.func,
   style: _react["default"].PropTypes.object
 };
-var _default = Button;
-exports["default"] = _default;
-var A;
-A = [1, 2, 2, 2];
-
-function abc() {
-  var c = function cef() {
-    A = 'str';
-  };
-}
-
 Button.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -68,6 +57,16 @@ Button.__docgenInfo = {
     }
   }
 };
+var _default = Button;
+exports["default"] = _default;
+var A;
+A = [1, 2, 2, 2];
+
+function abc() {
+  var c = function cef() {
+    A = 'str';
+  };
+}
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/case3/actual.js"] = {

--- a/test/fixtures/case4/expected.js
+++ b/test/fixtures/case4/expected.js
@@ -25,17 +25,6 @@ Button.propTypes = {
   onClick: _react["default"].PropTypes.func,
   style: _react["default"].PropTypes.object
 };
-var _default = Button;
-exports["default"] = _default;
-var A;
-A = [1, 2, 2, 2];
-
-function abc() {
-  var c = function cef() {
-    A = 'str';
-  };
-}
-
 Button.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -68,6 +57,16 @@ Button.__docgenInfo = {
     }
   }
 };
+var _default = Button;
+exports["default"] = _default;
+var A;
+A = [1, 2, 2, 2];
+
+function abc() {
+  var c = function cef() {
+    A = 'str';
+  };
+}
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/case4/actual.js"] = {

--- a/test/fixtures/case5/expected.js
+++ b/test/fixtures/case5/expected.js
@@ -21,8 +21,6 @@ var First = function First(_ref) {
 First.propTypes = {
   children: _react.PropTypes.node
 };
-var _default = First;
-exports["default"] = _default;
 First.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -37,6 +35,8 @@ First.__docgenInfo = {
     }
   }
 };
+var _default = First;
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/case5/actual.js"] = {

--- a/test/fixtures/example/expected.js
+++ b/test/fixtures/example/expected.js
@@ -64,13 +64,13 @@ function (_Component) {
   return App;
 }(_react.Component);
 
-var _default = App;
-exports["default"] = _default;
 App.__docgenInfo = {
   "description": "",
   "methods": [],
   "displayName": "App"
 };
+var _default = App;
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/example/actual.js"] = {

--- a/test/fixtures/flowType/expected.js
+++ b/test/fixtures/flowType/expected.js
@@ -66,8 +66,6 @@ function (_React$Component) {
   return FlowTypeButton;
 }(_react["default"].Component);
 
-var _default = FlowTypeButton;
-exports["default"] = _default;
 FlowTypeButton.__docgenInfo = {
   "description": "",
   "methods": [{
@@ -107,6 +105,8 @@ FlowTypeButton.__docgenInfo = {
     }
   }
 };
+var _default = FlowTypeButton;
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/flowType/actual.js"] = {

--- a/test/fixtures/functionDeclaration/expected.js
+++ b/test/fixtures/functionDeclaration/expected.js
@@ -21,8 +21,6 @@ function FuncDeclaration(_ref) {
 FuncDeclaration.propTypes = {
   children: _react.PropTypes.node
 };
-var _default = FuncDeclaration;
-exports["default"] = _default;
 FuncDeclaration.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -37,6 +35,8 @@ FuncDeclaration.__docgenInfo = {
     }
   }
 };
+var _default = FuncDeclaration;
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/functionDeclaration/actual.js"] = {

--- a/test/fixtures/hoc-function/expected.js
+++ b/test/fixtures/hoc-function/expected.js
@@ -31,9 +31,6 @@ TestComponent.propTypes = {
   onClick: _propTypes["default"].func
 };
 
-var _default = (0, _reactRedux.connect)(_testSelector.mapStateToProps, _testSelector.mapDispatchToProps)(TestComponent);
-
-exports["default"] = _default;
 TestComponent.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -55,6 +52,10 @@ TestComponent.__docgenInfo = {
     }
   }
 };
+
+var _default = (0, _reactRedux.connect)(_testSelector.mapStateToProps, _testSelector.mapDispatchToProps)(TestComponent);
+
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/hoc-function/actual.js"] = {

--- a/test/fixtures/hoc-function/expected.js
+++ b/test/fixtures/hoc-function/expected.js
@@ -30,7 +30,6 @@ TestComponent.propTypes = {
   /** Called on click */
   onClick: _propTypes["default"].func
 };
-
 TestComponent.__docgenInfo = {
   "description": "",
   "methods": [],

--- a/test/fixtures/hoc-multiple/actual.js
+++ b/test/fixtures/hoc-multiple/actual.js
@@ -17,3 +17,14 @@ Component.propTypes = {
 }
 
 export default withHoc()(deeperHoc(Component))
+
+class CompA extends React.Component {
+  render() { return null }
+}
+
+CompA.propTypes = {
+  /** Fancy styles in here */
+  myProp: React.PropTypes.object,
+}
+
+export { CompA }

--- a/test/fixtures/hoc-multiple/expected.js
+++ b/test/fixtures/hoc-multiple/expected.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = void 0;
+exports.CompA = exports["default"] = void 0;
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -95,10 +95,60 @@ var _default = withHoc()(deeperHoc(Component));
 
 exports["default"] = _default;
 
+var CompA =
+/*#__PURE__*/
+function (_React$Component2) {
+  _inherits(CompA, _React$Component2);
+
+  function CompA() {
+    _classCallCheck(this, CompA);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(CompA).apply(this, arguments));
+  }
+
+  _createClass(CompA, [{
+    key: "render",
+    value: function render() {
+      return null;
+    }
+  }]);
+
+  return CompA;
+}(React.Component);
+
+exports.CompA = CompA;
+CompA.propTypes = {
+  /** Fancy styles in here */
+  myProp: React.PropTypes.object
+};
+CompA.__docgenInfo = {
+  "description": "",
+  "methods": [],
+  "displayName": "CompA",
+  "props": {
+    "myProp": {
+      "type": {
+        "name": "custom",
+        "raw": "React.PropTypes.object"
+      },
+      "required": false,
+      "description": "Fancy styles in here"
+    }
+  }
+};
+
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/hoc-multiple/actual.js"] = {
     name: "Component",
     docgenInfo: Component.__docgenInfo,
+    path: "test/fixtures/hoc-multiple/actual.js"
+  };
+}
+
+if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
+  STORYBOOK_REACT_CLASSES["test/fixtures/hoc-multiple/actual.js"] = {
+    name: "CompA",
+    docgenInfo: CompA.__docgenInfo,
     path: "test/fixtures/hoc-multiple/actual.js"
   };
 }

--- a/test/fixtures/hoc-multiple/expected.js
+++ b/test/fixtures/hoc-multiple/expected.js
@@ -59,10 +59,6 @@ Component.propTypes = {
   /** Fancy styles in here */
   style: React.PropTypes.object
 };
-
-var _default = withHoc()(deeperHoc(Component));
-
-exports["default"] = _default;
 Component.__docgenInfo = {
   "description": "Super tiny component",
   "methods": [],
@@ -94,6 +90,10 @@ Component.__docgenInfo = {
     }
   }
 };
+
+var _default = withHoc()(deeperHoc(Component));
+
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/hoc-multiple/actual.js"] = {

--- a/test/fixtures/hoc/expected.js
+++ b/test/fixtures/hoc/expected.js
@@ -59,10 +59,6 @@ Component.propTypes = {
   /** Fancy styles in here */
   style: React.PropTypes.object
 };
-
-var _default = withHoc(Component);
-
-exports["default"] = _default;
 Component.__docgenInfo = {
   "description": "Super tiny component",
   "methods": [],
@@ -94,6 +90,10 @@ Component.__docgenInfo = {
     }
   }
 };
+
+var _default = withHoc(Component);
+
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/hoc/actual.js"] = {

--- a/test/fixtures/multiple-exports/expected.js
+++ b/test/fixtures/multiple-exports/expected.js
@@ -56,6 +56,20 @@ function (_React$Component) {
 ErrorBox.propTypes = {
   children: _react["default"].PropTypes.node.isRequired
 };
+ErrorBox.__docgenInfo = {
+  "description": "",
+  "methods": [],
+  "displayName": "ErrorBox",
+  "props": {
+    "children": {
+      "type": {
+        "name": "node"
+      },
+      "required": true,
+      "description": ""
+    }
+  }
+};
 var _default = ErrorBox;
 exports["default"] = _default;
 
@@ -87,12 +101,12 @@ exports.ErrorBox2 = ErrorBox2;
 ErrorBox2.propTypes = {
   children2: _react["default"].PropTypes.node.isRequired
 };
-ErrorBox.__docgenInfo = {
+ErrorBox2.__docgenInfo = {
   "description": "",
   "methods": [],
-  "displayName": "ErrorBox",
+  "displayName": "ErrorBox2",
   "props": {
-    "children": {
+    "children2": {
       "type": {
         "name": "node"
       },
@@ -109,21 +123,6 @@ if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
     path: "test/fixtures/multiple-exports/actual.js"
   };
 }
-
-ErrorBox2.__docgenInfo = {
-  "description": "",
-  "methods": [],
-  "displayName": "ErrorBox2",
-  "props": {
-    "children2": {
-      "type": {
-        "name": "node"
-      },
-      "required": true,
-      "description": ""
-    }
-  }
-};
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/multiple-exports/actual.js"] = {

--- a/test/fixtures/multiple-exports/expected.js
+++ b/test/fixtures/multiple-exports/expected.js
@@ -101,6 +101,15 @@ exports.ErrorBox2 = ErrorBox2;
 ErrorBox2.propTypes = {
   children2: _react["default"].PropTypes.node.isRequired
 };
+
+if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
+  STORYBOOK_REACT_CLASSES["test/fixtures/multiple-exports/actual.js"] = {
+    name: "ErrorBox",
+    docgenInfo: ErrorBox.__docgenInfo,
+    path: "test/fixtures/multiple-exports/actual.js"
+  };
+}
+
 ErrorBox2.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -115,14 +124,6 @@ ErrorBox2.__docgenInfo = {
     }
   }
 };
-
-if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
-  STORYBOOK_REACT_CLASSES["test/fixtures/multiple-exports/actual.js"] = {
-    name: "ErrorBox",
-    docgenInfo: ErrorBox.__docgenInfo,
-    path: "test/fixtures/multiple-exports/actual.js"
-  };
-}
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/multiple-exports/actual.js"] = {

--- a/test/fixtures/multiple-exports/expected.js
+++ b/test/fixtures/multiple-exports/expected.js
@@ -101,15 +101,6 @@ exports.ErrorBox2 = ErrorBox2;
 ErrorBox2.propTypes = {
   children2: _react["default"].PropTypes.node.isRequired
 };
-
-if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
-  STORYBOOK_REACT_CLASSES["test/fixtures/multiple-exports/actual.js"] = {
-    name: "ErrorBox",
-    docgenInfo: ErrorBox.__docgenInfo,
-    path: "test/fixtures/multiple-exports/actual.js"
-  };
-}
-
 ErrorBox2.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -124,6 +115,14 @@ ErrorBox2.__docgenInfo = {
     }
   }
 };
+
+if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
+  STORYBOOK_REACT_CLASSES["test/fixtures/multiple-exports/actual.js"] = {
+    name: "ErrorBox",
+    docgenInfo: ErrorBox.__docgenInfo,
+    path: "test/fixtures/multiple-exports/actual.js"
+  };
+}
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/multiple-exports/actual.js"] = {

--- a/test/fixtures/multipleExports2/expected.js
+++ b/test/fixtures/multipleExports2/expected.js
@@ -137,8 +137,6 @@ Breadcrumb.defaultProps = {
   className: '',
   foreColor: ''
 };
-var _default = Breadcrumb;
-exports["default"] = _default;
 Breadcrumb.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -263,6 +261,8 @@ Breadcrumb.__docgenInfo = {
     }
   }
 };
+var _default = Breadcrumb;
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/multipleExports2/actual.js"] = {

--- a/test/fixtures/reactCreateElement/expected.js
+++ b/test/fixtures/reactCreateElement/expected.js
@@ -32,8 +32,6 @@ Kitten.defaultProps = {
   isWide: false,
   isLong: false
 };
-var _default = Kitten;
-exports["default"] = _default;
 Kitten.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -63,6 +61,8 @@ Kitten.__docgenInfo = {
     }
   }
 };
+var _default = Kitten;
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/reactCreateElement/actual.js"] = {

--- a/test/fixtures/with-custom-handlers/expected.js
+++ b/test/fixtures/with-custom-handlers/expected.js
@@ -57,8 +57,6 @@ ErrorBox.propTypes = {
   /** @deprecated This is the description for prop */
   deprecatedProp: _react["default"].PropTypes.number
 };
-var _default = ErrorBox;
-exports["default"] = _default;
 ErrorBox.__docgenInfo = {
   "description": "",
   "methods": [],
@@ -74,6 +72,8 @@ ErrorBox.__docgenInfo = {
     }
   }
 };
+var _default = ErrorBox;
+exports["default"] = _default;
 
 if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
   STORYBOOK_REACT_CLASSES["test/fixtures/with-custom-handlers/actual.js"] = {

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ function trim(str) {
   return str.replace(/^\s+|\s+$/, '');
 }
 
-describe('Add propType doc to react classes', () => {
+describe('Add propType doc to react components', () => {
   const fixturesDir = path.join(__dirname, 'fixtures');
   fs.readdirSync(fixturesDir).map((caseName) => {
     // Ignore macOS directory files


### PR DESCRIPTION
I think #48 deserves to be re-opened. The problem isn't that it doesn't support HoC, the problem is that the `__docgenInfo` is set **after** the HoC call. This doesn't let the HoC wrapper hoist the statics into the parent component and hence even though the `__docgenInfo` is created, it is hidden underneath the HoC wrapper.

I am opening this PR to start a discussion.

- [x] Fix the test by adding the `__docgenInfo` before HoC call

/cc @danielduan @madushan1000