### PR TITLE
Provide filename to the babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-  "presets": [
-    "@babel/env",
-  ]
+  "presets": ["@babel/env", "@babel/flow", "@babel/react"],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ export default function({ types: t }) {
 }
 
 function injectReactDocgenInfo(path, state, code, t) {
+  const { filename } = state.file.opts;
   const program = path.scope.getProgramParent().path;
 
   let docgenResults = [];
@@ -36,7 +37,9 @@ function injectReactDocgenInfo(path, state, code, t) {
     }
 
     const handlers = [...defaultHandlers, ...customHandlers, actualNameHandler];
-    docgenResults = ReactDocgen.parse(code, resolver, handlers);
+    docgenResults = ReactDocgen.parse(code, resolver, handlers, {
+      filename,
+    });
 
     if (state.opts.removeMethods) {
       docgenResults.forEach(function(docgenResult) {


### PR DESCRIPTION
There are some issues without that option (see https://babeljs.io/docs/en/options#filename), including problems with `typescript` too, that I faced with.

Should resolve #66