### PR TITLE
feat: add preHandlers or transforms for AST data for react functionComponents in typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ So, we allow you to collect all the docgen info into a global collection. To do 
         "DOC_GEN_COLLECTION_NAME": "MY_REACT_DOCS",
         "resolver": "findAllComponentDefinitions", // optional (default: findAllExportedComponentDefinitions)
         "removeMethods": true, // optional (default: false)
+        "preHandlers": ["react-docgen-custom-transform"] // optional array of custom transforming handlers running before the actual handlers (use the string name of the package in the array)
         "handlers:": ["react-docgen-deprecation-handler"] // optional array of custom handlers (use the string name of the package in the array)
       }
     ]

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,14 @@ function injectReactDocgenInfo(path, state, code, t) {
       });
     }
 
-    const handlers = [...defaultHandlers, ...customHandlers, actualNameHandler];
+    let preHandlers = [];
+    if (state.opts.preHandlers) {
+        state.opts.preHandlers.forEach(handler => {
+            preHandlers.push(require(handler));
+        });
+      }
+
+    const handlers = [...preHandlers, ...defaultHandlers, ...customHandlers, actualNameHandler];
     docgenResults = ReactDocgen.parse(code, resolver, handlers, {
       filename,
     });


### PR DESCRIPTION
Hello,

I would like to suggest a PR with preHandlers in order get defined type from React.functionComponent definitions working in Storybook without rewriting these definitions for the users of storybook. Please find example [here](https://codesandbox.io/s/initial-600-beta22-config-working-prototype-with-showing-props-react-docgen-ftvf2).

I made react.functionComponent definitions written in typescript work with `react-docgen` via this [custom handler](https://www.npmjs.com/package/typescript-react-function-component-props-handler). It helps to get defined type from React.functionComponent definition:

```ts

type ComponentType = {
    text?: string;
};

const Component: React.FunctionComponent<ComponentType> = (props) => (...);

```

In order to make it work we need to add preHandlers - which can be called included in handlers array and called first before the actual default handlers.

Main benefit of this approach - it allows to support and cover UI-component props in storybook without rewriting definitions of types for props. [Initial discussion](https://github.com/reactjs/react-docgen/issues/387) was raised in `react-docgen` repo.