### PR TITLE
Allow more configuration of react-docgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ Use it inside your `.babelrc`
 
 |  option  |  description   |  default   |
 | --- | --- | --- |
-| resolver      | You may use the 3 built-in [react-docgen resolvers](https://github.com/reactjs/react-docgen#resolver-1) by specifying its name as a `string`, or you may specify a custom resolver by specifying the function explicitly.  | ```"findAllExportedComponentDefinition"``` |
-| handlers      | All [react-docgen handlers](https://github.com/reactjs/react-docgen#handlers-1) are automatically applied. However, custom handlers can be added by specifying them here. Any `string` value will be loaded by `require`, and a `function` will be used directly. |  |
-| removeMethods | Used to remove docgen information about methods |   ```false```  |
+| resolver                | You may use the 3 built-in [react-docgen resolvers](https://github.com/reactjs/react-docgen#resolver-1) by specifying its name as a `string`, or you may specify a custom resolver by specifying the function explicitly.  | ```"findAllExportedComponentDefinition"``` |
+| handlers                | All [react-docgen handlers](https://github.com/reactjs/react-docgen#handlers-1) are automatically applied. However, custom handlers can be added by specifying them here. Any `string` value will be loaded by `require`, and a `function` will be used directly. |  |
+| removeMethods           | Used to remove docgen information about methods. |   ```false```  |
+| DOC_GEN_COLLECTION_NAME | The name of a global variable where all docgen information can be stored. See [below](#collect-all-docgen-info) for more information. | |
+| ...options              | Remaining options will be passed directly as [react-docgen options](https://github.com/reactjs/react-docgen#options). Any options they allowed will be passed through, but the `filename` will be overwritten by the filename provided by babel. | |
 
 ## Collect All Docgen Info
 
@@ -128,10 +130,9 @@ if (typeof MY_REACT_DOCS !== 'undefined') {
 
 ## Compile Performance
 
-Now, we parse your code with `react-docgen` to get these info.
-But we only do it for files which has a React component.
+We parse your code with `react-docgen` to get this info, but we only do it for files which contain a React component.
 
-Yes, this will add some overhead to your project. But once you turned on [babel cache directory](http://stackoverflow.com/a/30384710) this won't be a big issue.
+There will be some overhead to your project, but you can leverage [babel's cache directory](http://stackoverflow.com/a/30384710) to avoid this a huge performance hit.
 
 ## Output Size
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ Use it inside your `.babelrc`
 
 |  option  |  description   |  default   |
 | --- | --- | --- |
-|   resolver  |   [react-docgen](https://github.com/reactjs/react-docgen) has 3 built in resolvers which may be used. Resolvers define how/what the doc generator will inspect. You may inspect the existing resolvers in [react-docgen/tree/master/src/resolver](https://github.com/reactjs/react-docgen/tree/master/src/resolver).  | ```"findAllExportedComponentDefinition"``` |
-|   removeMethods  | optionally remove docgen information about methods |   ```false```  |
+| resolver      | You may use the 3 built-in [react-docgen resolvers](https://github.com/reactjs/react-docgen#resolver-1) by specifying its name as a `string`, or you may specify a custom resolver by specifying the function explicitly.  | ```"findAllExportedComponentDefinition"``` |
+| handlers      | All [react-docgen handlers](https://github.com/reactjs/react-docgen#handlers-1) are automatically applied. However, custom handlers can be added by specifying them here. Any `string` value will be loaded by `require`, and a `function` will be used directly. |  |
+| removeMethods | Used to remove docgen information about methods |   ```false```  |
 
 ## Collect All Docgen Info
 
@@ -105,7 +106,7 @@ So, we allow you to collect all the docgen info into a global collection. To do 
         "DOC_GEN_COLLECTION_NAME": "MY_REACT_DOCS",
         "resolver": "findAllComponentDefinitions", // optional (default: findAllExportedComponentDefinitions)
         "removeMethods": true, // optional (default: false)
-        "handlers:": ["react-docgen-deprecation-handler"] // optional array of custom handlers (use the string name of the package in the array)
+        "handlers": ["react-docgen-deprecation-handler"] // optional array of custom handlers
       }
     ]
   ]

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,10 @@ function injectReactDocgenInfo(path, state, code, t) {
       filename,
     });
 
+    if (docgenResults && !Array.isArray(docgenResults)) {
+      docgenResults = [docgenResults];
+    }
+
     if (state.opts.removeMethods) {
       docgenResults.forEach(function(docgenResult) {
         delete docgenResult.methods;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 import * as _ from 'lodash';
 import * as ReactDocgen from 'react-docgen';
-import * as reactDocgenHandlers from 'react-docgen/dist/handlers';
 import actualNameHandler from './actualNameHandler';
 import { relativePath } from './relativePath';
 
-const defaultHandlers = Object.values(reactDocgenHandlers).map(handler => handler);
+const defaultHandlers = Object.values(ReactDocgen.handlers).map(handler => handler);
 
 export default function({ types: t }) {
   return {
@@ -25,14 +24,20 @@ function injectReactDocgenInfo(path, state, code, t) {
   let docgenResults = [];
   try {
     let resolver = ReactDocgen.resolver.findAllExportedComponentDefinitions;
-    if (state.opts.resolver) {
+    if (typeof state.opts.resolver === 'string') {
       resolver = ReactDocgen.resolver[state.opts.resolver];
+    } else if (typeof state.opts.resolver === 'function') {
+      resolver = state.opts.resolver;
     }
 
     let customHandlers = [];
     if (state.opts.handlers) {
       state.opts.handlers.forEach(handler => {
-        customHandlers.push(require(handler));
+        if (typeof handler === 'string') {
+          customHandlers.push(require(handler));
+        } else if (typeof handler === 'function') {
+          customHandlers.push(handler);
+        }
       });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,18 +21,25 @@ function injectReactDocgenInfo(path, state, code, t) {
   const { filename } = state.file.opts;
   const program = path.scope.getProgramParent().path;
 
+  const {
+    resolver: resolverOpt,
+    handlers: handlersOpt,
+    DOC_GEN_COLLECTION_NAME,
+    ...opts
+  } = state.opts;
+
   let docgenResults = [];
   try {
     let resolver = ReactDocgen.resolver.findAllExportedComponentDefinitions;
-    if (typeof state.opts.resolver === 'string') {
-      resolver = ReactDocgen.resolver[state.opts.resolver];
-    } else if (typeof state.opts.resolver === 'function') {
-      resolver = state.opts.resolver;
+    if (typeof resolverOpt === 'string') {
+      resolver = ReactDocgen.resolver[resolverOpt];
+    } else if (typeof resolverOpt === 'function') {
+      resolver = resolverOpt;
     }
 
     let customHandlers = [];
-    if (state.opts.handlers) {
-      state.opts.handlers.forEach(handler => {
+    if (handlersOpt) {
+      handlersOpt.forEach(handler => {
         if (typeof handler === 'string') {
           customHandlers.push(require(handler));
         } else if (typeof handler === 'function') {
@@ -43,6 +50,7 @@ function injectReactDocgenInfo(path, state, code, t) {
 
     const handlers = [...defaultHandlers, ...customHandlers, actualNameHandler];
     docgenResults = ReactDocgen.parse(code, resolver, handlers, {
+      ...opts,
       filename,
     });
 

--- a/test/fixtures/case1/output.js
+++ b/test/fixtures/case1/output.js
@@ -475,3 +475,479 @@ if (typeof STORYBOOK_REACT_CLASSES !== \\"undefined\\") {
   };
 }"
 `;
+
+exports[`options allows custom resolver to accept string that matches an available react-docgen resolver 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+exports[\\"default\\"] = exports.TOUCHSTART_TIMEOUT = void 0;
+
+var _react = _interopRequireWildcard(require(\\"react\\"));
+
+var _reactAddonsShallowCompare = _interopRequireDefault(require(\\"react-addons-shallow-compare\\"));
+
+var _reactMomentProptypes = _interopRequireDefault(require(\\"react-moment-proptypes\\"));
+
+var _moment = _interopRequireDefault(require(\\"moment\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { \\"default\\": obj }; }
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== \\"function\\") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== \\"object\\" && typeof obj !== \\"function\\") { return { \\"default\\": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj[\\"default\\"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function _typeof(obj) { if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === \\"object\\" || typeof call === \\"function\\")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function\\"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var TOUCHSTART_TIMEOUT = 200;
+exports.TOUCHSTART_TIMEOUT = TOUCHSTART_TIMEOUT;
+var propTypes = {
+  day: _reactMomentProptypes[\\"default\\"].momentObj,
+  modifiers: _react.PropTypes.arrayOf(_react.PropTypes.string),
+  onDayClick: _react.PropTypes.func,
+  onDayMouseDown: _react.PropTypes.func,
+  onDayMouseUp: _react.PropTypes.func,
+  onDayMouseEnter: _react.PropTypes.func,
+  onDayMouseLeave: _react.PropTypes.func,
+  onDayTouchStart: _react.PropTypes.func,
+  onDayTouchEnd: _react.PropTypes.func,
+  onDayTouchTap: _react.PropTypes.func,
+  'hypen-dash': _react.PropTypes.string
+};
+var defaultProps = {
+  day: (0, _moment[\\"default\\"])(),
+  modifiers: [],
+  onDayClick: function onDayClick() {},
+  onDayMouseDown: function onDayMouseDown() {},
+  onDayMouseUp: function onDayMouseUp() {},
+  onDayMouseEnter: function onDayMouseEnter() {},
+  onDayMouseLeave: function onDayMouseLeave() {},
+  onDayTouchStart: function onDayTouchStart() {},
+  onDayTouchEnd: function onDayTouchEnd() {},
+  onDayTouchTap: function onDayTouchTap() {},
+  'hypen-dash': 'hello'
+};
+
+var CalendarDay =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(CalendarDay, _React$Component);
+
+  function CalendarDay(props) {
+    var _this;
+
+    _classCallCheck(this, CalendarDay);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(CalendarDay).call(this, props));
+    _this.hasActiveTouchStart = false;
+    return _this;
+  }
+
+  _createClass(CalendarDay, [{
+    key: \\"shouldComponentUpdate\\",
+    value: function shouldComponentUpdate(nextProps, nextState) {
+      return (0, _reactAddonsShallowCompare[\\"default\\"])(this, nextProps, nextState);
+    }
+    /**
+     * Some description about how handleDayClick works
+     * @param  {Object} day this is a moment js object
+     * @param  {number|string} modifiers hello world
+     * @param  {number=} e events yo
+     * @return {*} wut return
+     */
+
+  }, {
+    key: \\"handleDayClick\\",
+    value: function handleDayClick(day, modifiers, e) {
+      this.props.onDayClick(day, modifiers, e);
+    }
+  }, {
+    key: \\"handleDayMouseDown\\",
+    value: function handleDayMouseDown(day, modifiers, e) {
+      this.props.onDayMouseDown(day, modifiers, e);
+    }
+  }, {
+    key: \\"handleDayMouseUp\\",
+    value: function handleDayMouseUp(day, modifiers, e) {
+      this.props.onDayMouseUp(day, modifiers, e);
+    }
+  }, {
+    key: \\"handleDayMouseEnter\\",
+    value: function handleDayMouseEnter(day, modifiers, e) {
+      this.props.onDayMouseEnter(day, modifiers, e);
+    }
+  }, {
+    key: \\"handleDayMouseLeave\\",
+    value: function handleDayMouseLeave(day, modifiers, e) {
+      this.props.onDayMouseLeave(day, modifiers, e);
+    }
+  }, {
+    key: \\"handleDayTouchStart\\",
+    value: function handleDayTouchStart(day, modifiers, e) {
+      var _this2 = this;
+
+      this.hasActiveTouchStart = true;
+      setTimeout(function () {
+        _this2.hasActiveTouchStart = false;
+      }, TOUCHSTART_TIMEOUT);
+      this.props.onDayTouchStart(day, modifiers, e);
+    }
+  }, {
+    key: \\"handleDayTouchEnd\\",
+    value: function handleDayTouchEnd(day, modifiers, e) {
+      if (this.hasActiveTouchStart) {
+        this.hasActiveTouchStart = false;
+        this.handleDayTouchTap(day, modifiers, e);
+      }
+
+      this.props.onDayTouchEnd(day, modifiers, e);
+    }
+  }, {
+    key: \\"handleDayTouchTap\\",
+    value: function handleDayTouchTap(day, modifiers, e) {
+      this.props.onDayTouchTap(day, modifiers, e);
+    }
+  }, {
+    key: \\"render\\",
+    value: function render() {
+      var _this3 = this;
+
+      var _this$props = this.props,
+          day = _this$props.day,
+          modifiers = _this$props.modifiers;
+      return _react[\\"default\\"].createElement(\\"div\\", {
+        className: \\"CalendarDay\\",
+        onMouseEnter: function onMouseEnter(e) {
+          return _this3.handleDayMouseEnter(day, modifiers, e);
+        },
+        onMouseLeave: function onMouseLeave(e) {
+          return _this3.handleDayMouseLeave(day, modifiers, e);
+        },
+        onMouseDown: function onMouseDown(e) {
+          return _this3.handleDayMouseDown(day, modifiers, e);
+        },
+        onMouseUp: function onMouseUp(e) {
+          return _this3.handleDayMouseUp(day, modifiers, e);
+        },
+        onClick: function onClick(e) {
+          return _this3.handleDayClick(day, modifiers, e);
+        },
+        onTouchStart: function onTouchStart(e) {
+          return _this3.handleDayTouchStart(day, modifiers, e);
+        },
+        onTouchEnd: function onTouchEnd(e) {
+          return _this3.handleDayTouchEnd(day, modifiers, e);
+        }
+      }, _react[\\"default\\"].createElement(\\"span\\", {
+        className: \\"CalendarDay__day\\"
+      }, day.format('D')));
+    }
+  }]);
+
+  return CalendarDay;
+}(_react[\\"default\\"].Component);
+
+exports[\\"default\\"] = CalendarDay;
+CalendarDay.propTypes = propTypes;
+CalendarDay.defaultProps = defaultProps;
+CalendarDay.__docgenInfo = {
+  \\"description\\": \\"\\",
+  \\"methods\\": [{
+    \\"name\\": \\"handleDayClick\\",
+    \\"docblock\\": \\"Some description about how handleDayClick works\\\\n@param  {Object} day this is a moment js object\\\\n@param  {number|string} modifiers hello world\\\\n@param  {number=} e events yo\\\\n@return {*} wut return\\",
+    \\"modifiers\\": [],
+    \\"params\\": [{
+      \\"name\\": \\"day\\",
+      \\"description\\": \\"this is a moment js object\\",
+      \\"type\\": {
+        \\"name\\": \\"Object\\"
+      },
+      \\"optional\\": false
+    }, {
+      \\"name\\": \\"modifiers\\",
+      \\"description\\": \\"hello world\\",
+      \\"type\\": {
+        \\"name\\": \\"union\\",
+        \\"elements\\": [{
+          \\"name\\": \\"number\\"
+        }, {
+          \\"name\\": \\"string\\"
+        }]
+      },
+      \\"optional\\": false
+    }, {
+      \\"name\\": \\"e\\",
+      \\"description\\": \\"events yo\\",
+      \\"type\\": {
+        \\"name\\": \\"number\\"
+      },
+      \\"optional\\": true
+    }],
+    \\"returns\\": {
+      \\"description\\": \\"wut return\\",
+      \\"type\\": {
+        \\"name\\": \\"mixed\\"
+      }
+    },
+    \\"description\\": \\"Some description about how handleDayClick works\\"
+  }, {
+    \\"name\\": \\"handleDayMouseDown\\",
+    \\"docblock\\": null,
+    \\"modifiers\\": [],
+    \\"params\\": [{
+      \\"name\\": \\"day\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"modifiers\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"e\\",
+      \\"type\\": null
+    }],
+    \\"returns\\": null
+  }, {
+    \\"name\\": \\"handleDayMouseUp\\",
+    \\"docblock\\": null,
+    \\"modifiers\\": [],
+    \\"params\\": [{
+      \\"name\\": \\"day\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"modifiers\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"e\\",
+      \\"type\\": null
+    }],
+    \\"returns\\": null
+  }, {
+    \\"name\\": \\"handleDayMouseEnter\\",
+    \\"docblock\\": null,
+    \\"modifiers\\": [],
+    \\"params\\": [{
+      \\"name\\": \\"day\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"modifiers\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"e\\",
+      \\"type\\": null
+    }],
+    \\"returns\\": null
+  }, {
+    \\"name\\": \\"handleDayMouseLeave\\",
+    \\"docblock\\": null,
+    \\"modifiers\\": [],
+    \\"params\\": [{
+      \\"name\\": \\"day\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"modifiers\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"e\\",
+      \\"type\\": null
+    }],
+    \\"returns\\": null
+  }, {
+    \\"name\\": \\"handleDayTouchStart\\",
+    \\"docblock\\": null,
+    \\"modifiers\\": [],
+    \\"params\\": [{
+      \\"name\\": \\"day\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"modifiers\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"e\\",
+      \\"type\\": null
+    }],
+    \\"returns\\": null
+  }, {
+    \\"name\\": \\"handleDayTouchEnd\\",
+    \\"docblock\\": null,
+    \\"modifiers\\": [],
+    \\"params\\": [{
+      \\"name\\": \\"day\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"modifiers\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"e\\",
+      \\"type\\": null
+    }],
+    \\"returns\\": null
+  }, {
+    \\"name\\": \\"handleDayTouchTap\\",
+    \\"docblock\\": null,
+    \\"modifiers\\": [],
+    \\"params\\": [{
+      \\"name\\": \\"day\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"modifiers\\",
+      \\"type\\": null
+    }, {
+      \\"name\\": \\"e\\",
+      \\"type\\": null
+    }],
+    \\"returns\\": null
+  }],
+  \\"displayName\\": \\"CalendarDay\\",
+  \\"props\\": {
+    \\"day\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"moment()\\",
+        \\"computed\\": true
+      },
+      \\"type\\": {
+        \\"name\\": \\"custom\\",
+        \\"raw\\": \\"momentPropTypes.momentObj\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"modifiers\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"[]\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"arrayOf\\",
+        \\"value\\": {
+          \\"name\\": \\"string\\"
+        }
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"onDayClick\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"() {}\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"func\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"onDayMouseDown\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"() {}\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"func\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"onDayMouseUp\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"() {}\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"func\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"onDayMouseEnter\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"() {}\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"func\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"onDayMouseLeave\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"() {}\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"func\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"onDayTouchStart\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"() {}\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"func\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"onDayTouchEnd\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"() {}\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"func\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"onDayTouchTap\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"() {}\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"func\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    },
+    \\"hypen-dash\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"'hello'\\",
+        \\"computed\\": false
+      },
+      \\"type\\": {
+        \\"name\\": \\"string\\"
+      },
+      \\"required\\": false,
+      \\"description\\": \\"\\"
+    }
+  }
+};
+
+if (typeof STORYBOOK_REACT_CLASSES !== \\"undefined\\") {
+  STORYBOOK_REACT_CLASSES[\\"relativePath(input.js)\\"] = {
+    name: \\"CalendarDay\\",
+    docgenInfo: CalendarDay.__docgenInfo,
+    path: \\"relativePath(input.js)\\"
+  };
+}"
+`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { transformFileSync } from '@babel/core';
 import plugin from '../src';
+import { resolver } from 'react-docgen';
 
 jest.mock('../src/relativePath', () => ({
   relativePath: filename => {
@@ -41,5 +42,57 @@ describe('Add propType doc to react components', () => {
         expect(output).toMatchSpecificSnapshot(outputPath);
       });
     }
+  });
+});
+
+describe('options', () => {
+  const fixturesDir = path.join(__dirname, 'fixtures');
+  const fixtureDir = path.join(fixturesDir, 'case1');
+  const inputPath = path.join(fixtureDir, 'input.js');
+  const outputPath = path.join(fixtureDir, 'output.js');
+
+  it('allows custom resolver to accept string that matches an available react-docgen resolver', () => {
+    const options = {
+      presets: ['@babel/env', '@babel/flow', '@babel/react'],
+      plugins: [
+        [
+          plugin,
+          {
+            DOC_GEN_COLLECTION_NAME: 'STORYBOOK_REACT_CLASSES',
+            resolver: 'findExportedComponentDefinition',
+          },
+        ],
+        '@babel/plugin-proposal-class-properties',
+      ],
+      babelrc: false,
+    };
+
+    const output = normalizeNewlines(transformFileSync(inputPath, options).code);
+    expect(output).toMatchSpecificSnapshot(outputPath);
+  })
+
+  it('allows custom resolvers & handlers to be functions', () => {
+    const customResolver = jest.fn(resolver.findExportedComponentDefinition);
+    const customHandler = jest.fn();
+
+    const options = {
+      presets: ['@babel/env', '@babel/flow', '@babel/react'],
+      plugins: [
+        [
+          plugin,
+          {
+            DOC_GEN_COLLECTION_NAME: 'STORYBOOK_REACT_CLASSES',
+            resolver: customResolver,
+            handlers: [customHandler],
+          },
+        ],
+        '@babel/plugin-proposal-class-properties',
+      ],
+      babelrc: false,
+    };
+
+    transformFileSync(inputPath, options);
+    expect(customResolver).toHaveBeenCalled();
+    expect(customHandler).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
In preparation for my react-docgen work that will allow importing types across a codebase, I also found that this babel plugin doesn't allow for as much configuration as is required to wire that up.

So, I expanded the options to allow passing more things to react-docgen. I also added more information to the options table to help people that will want to customize this plugin.

This also closes #82 & closes #83 