### PR TITLE
updated lodash from 4.17.15 to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "ast-types": "^0.14.2",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "react-docgen": "^5.0.0"
   },
   "license": "MIT"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3006,7 +3006,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Hi! 👋
This PR updates the version of lodash to fix https://github.com/advisories/GHSA-p6mc-m468-83gw.
The tests seem to pass, let me know if you need anything else!